### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This file documents changes to [fastapi-mvc/copier-project](https://github.com/f
 * Pin nix version in nix-install-action in templated nix workflow [6b4a13c](https://github.com/fastapi-mvc/copier-project/commit/6b4a13ca08b2590a6003ab46a5ef27ac1b139341).
 * Pin nix version in nix-install-action [8106966](https://github.com/fastapi-mvc/copier-project/commit/8106966aaaf40bdcee76079e4a4842128148dcbb).
 * Update generator with changes from [copier-generator](https://github.com/fastapi-mvc/copier-generator) 0.2.0 release. PR [#14](https://github.com/fastapi-mvc/copier-project/pull/14)
+* Update project dependencies. PR [#16](https://github.com/fastapi-mvc/copier-project/pull/16)
+  * Bump fastapi from 0.89.1 to 0.92.0.
+  * Bump myst-parser from 0.18.1 to 0.19.0.
+  * Bump redis from 4.4.2 to 4.5.1.
+  * Bump flake8-docstrings from 1.6.0 to 1.7.0.
+  * Bump aiohttp from 3.8.3 to 3.8.4.
 
 ## 0.4.0 (07.02.2023)
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -7,7 +7,7 @@
 [![K8s integration]({{repo_url}}/actions/workflows/integration.yml/badge.svg)]({{repo_url}}/actions/workflows/integration.yml)
 {%- endif %}
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![GitHub](https://img.shields.io/badge/fastapi-v.0.89.1-blue)
+![GitHub](https://img.shields.io/badge/fastapi-v.0.92.0-blue)
 ![GitHub](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
 ![GitHub](https://img.shields.io/badge/license-{{license}}-blue)
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -18,15 +18,15 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-fastapi = "~0.89.1"
+fastapi = "~0.92.0"
 uvicorn = {extras = ["standard"], version = "~0.20.0"}
 gunicorn = "~20.1.0"
 click = "~8.1.3"
 {%- if redis %}
-redis = "~4.4.0"
+redis = "~4.5.1"
 {%- endif %}
 {%- if aiohttp %}
-aiohttp = "~3.8.3"
+aiohttp = "~3.8.4"
 {%- endif %}
 
 [tool.poetry.dev-dependencies]
@@ -39,13 +39,13 @@ httpx = "~0.23.3"
 aioresponses = "~0.7.3"
 {%- endif %}
 flake8 = "~5.0.4"
-flake8-docstrings = "~1.6.0"
+flake8-docstrings = "~1.7.0"
 flake8-import-order = "~0.18.1"
 flake8-todo = "^0.7"
 black = "~23.1.0"
 Sphinx = "~5.3.0"
 Pallets-Sphinx-Themes = "~2.0.2"
-myst-parser = "~0.18.1"
+myst-parser = "~0.19.0"
 
 [tool.poetry.scripts]
 {{script_name}} = '{{package_name}}.cli:cli'


### PR DESCRIPTION
* Bump fastapi from 0.89.1 to 0.92.0.
* Bump myst-parser from 0.18.1 to 0.19.0.
* Bump redis from 4.4.2 to 4.5.1.
* Bump flake8-docstrings from 1.6.0 to 1.7.0.
* Bump aiohttp from 3.8.3 to 3.8.4.