### PR TITLE
Bump dependencies

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -7,7 +7,7 @@
 [![K8s integration]({{repo_url}}/actions/workflows/integration.yml/badge.svg)]({{repo_url}}/actions/workflows/integration.yml)
 {%- endif %}
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-![GitHub](https://img.shields.io/badge/fastapi-v.0.92.0-blue)
+![GitHub](https://img.shields.io/badge/fastapi-v.0.98.0-blue)
 ![GitHub](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
 ![GitHub](https://img.shields.io/badge/license-{{license}}-blue)
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -18,35 +18,35 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-fastapi = "~0.92.0"
-uvicorn = {extras = ["standard"], version = "~0.20.0"}
+fastapi = "~0.98.0"
+uvicorn = {extras = ["standard"], version = "~0.22.0"}
 gunicorn = "~20.1.0"
 click = "~8.1.3"
 {%- if redis %}
-redis = "~4.5.1"
+redis = "~4.5.5"
 {%- endif %}
 {%- if aiohttp %}
 aiohttp = "~3.8.4"
 {%- endif %}
 
 [tool.poetry.group.dev.dependencies]
-pytest = "~7.2.1"
+pytest = "~7.4.0"
 pytest-cov = "~4.0.0"
-pytest-asyncio = "~0.20.3"
+pytest-asyncio = "~0.21.0"
 requests = "~2.28.2"
 httpx = "~0.23.3"
 {%- if aiohttp %}
 aioresponses = "~0.7.3"
 {%- endif %}
-mypy = "~1.0.1"
+mypy = "~1.4.1"
 flake8 = "~5.0.4"
 flake8-docstrings = "~1.7.0"
 flake8-import-order = "~0.18.1"
 flake8-todo = "^0.7"
-black = "~23.1.0"
+black = "~23.3.0"
 Sphinx = "~5.3.0"
 Pallets-Sphinx-Themes = "~2.0.2"
-myst-parser = "~0.19.0"
+myst-parser = "~1.0.0"
 fastapi-mvc = "^0.26.0"
 
 [tool.poetry.scripts]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -74,6 +74,7 @@ exclude_lines = [
 exclude = [
     "config/gunicorn.py"
 ]
+plugins = "pydantic.mypy"
 python_version = '3.10'
 show_error_codes = true
 follow_imports = 'silent'

--- a/template/{% if nix %}flake.lock{% endif %}.jinja
+++ b/template/{% if nix %}flake.lock{% endif %}.jinja
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675681488,
-        "narHash": "sha256-0E/oYpixC+joFk7UrY60TwZcdthzP2BXmJwne3Ni8ZI=",
+        "lastModified": 1687829761,
+        "narHash": "sha256-QRe1Y8SS3M4GeC58F/6ajz6V0ZLUVWX3ZAMgov2N3/g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13fdd3945d8a2da5e4afe35d8a629193a9680911",
+        "rev": "9790f3242da2152d5aa1976e3e4b8b414f4dd206",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/template/{% if nix %}flake.nix{% endif %}.jinja
+++ b/template/{% if nix %}flake.nix{% endif %}.jinja
@@ -11,7 +11,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
     poetry2nix = {
       url = "github:nix-community/poetry2nix?ref=1.42.0";


### PR DESCRIPTION
* Update flake nixpkgs to 23.05

---

* Bump fastapi from 0.92.0 to 0.98.0
* Bump uvicorn from 0.20.0 to 0.22.0
 * Bump myst-parser from 0.19.0 to 1.0.0
 * Bump pytest from 7.2.1 to 7.4.0
* Bump pytest-asyncio from 0.20.3 to 0.21.0
 * Bump black from 23.1.0 to 23.6.0
 * Bump redis from 4.5.4 to 4.5.5
 * Bump mypy from 1.0.1 to 1.4.1